### PR TITLE
 verify the hex string is actually valid

### DIFF
--- a/packages/moleculer-db-adapter-mongo/src/index.js
+++ b/packages/moleculer-db-adapter-mongo/src/index.js
@@ -359,10 +359,11 @@ class MongoDbAdapter {
 	 * @memberof MongoDbAdapter
 	 */
 	stringToObjectID(id) {
-		if (typeof id == "string" && !isNaN(parseInt(id,16)) && ObjectID.isValid(id))
-			return new ObjectID.createFromHexString(id);
+        let re =  /^[0-9A-Fa-f]+$/gi;
+        if (typeof id == "string" && re.test(id) && id.length === 24  && ObjectID.isValid(id))
+            return new ObjectID.createFromHexString(id);
 
-		return id;
+        return id;
 	}
 
 	/**


### PR DESCRIPTION
There is a case where the string could be 12 characters and all valid hex.  This will  make the hex string pass, but then it will fail because it is not 24 characters long.

This fixes the issue by making sure that a hex string is 24 charcters long